### PR TITLE
#45 本番ではlivereload.jsは無効にする

### DIFF
--- a/docs/gitbook/gitbook-plugin-livereload/plugin.js
+++ b/docs/gitbook/gitbook-plugin-livereload/plugin.js
@@ -1,4 +1,6 @@
 (function() {
+  if (window.location.hostname === "tech-vision.connehito.com") return;
+
   var newEl = document.createElement('script'),
       firstScriptTag = document.getElementsByTagName('script')[0];
 


### PR DESCRIPTION
#45 

plugin.js 内で hostname を参照し、本番環境の場合は livereload を読み込まない設定にする

- dotenvでの管理方法も考えたのですが、HOSTNAMEしか参照しないので過剰かなと考え直接記述しました。
- 開発環境でもlivereloadが不要であればプラグインごとアンインストールしてもいいかなと思いましたのでご意見お願いいたします！